### PR TITLE
Updates for 2021.10.14.0

### DIFF
--- a/.github/workflows/generate_wheels_yml.py
+++ b/.github/workflows/generate_wheels_yml.py
@@ -171,7 +171,6 @@ def make_build_job(platform: str, arch: int, pyver: tuple) -> str:
         {py_cmd} -m auditwheel repair -w dist/wheelhouse/ dist/*.whl
         rm dist/*.whl
         mv dist/wheelhouse/* dist/
-        rm dist/*manylinux1*
         rm -rf dist/wheelhouse
     ''')}
     - name: Rename wheel file

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -810,7 +810,6 @@ jobs:
         /opt/python/cp36-cp36m/bin/python -m auditwheel repair -w dist/wheelhouse/ dist/*.whl
         rm dist/*.whl
         mv dist/wheelhouse/* dist/
-        rm dist/*manylinux1*
         rm -rf dist/wheelhouse
     - name: Rename wheel file
       shell: bash

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.5
+    - name: Set up Python 3.6
       uses: actions/setup-python@v2
       with:
-        python-version: "3.5"
+        python-version: "3.6"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -27,40 +27,14 @@ jobs:
       with:
         name: sdist
         path: dist
-  build-windows-32-27:
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: ilammy/msvc-dev-cmd@v1
-    - name: Set up Python 2.7
-      uses: actions/setup-python@v2
-      with:
-        python-version: 2.7
-        architecture: x86
-    - name: Install Microsoft Visual C++ Compiler for Python 2.7
-      uses: crazy-max/ghaction-chocolatey@v1
-      with:
-        args: install vcpython27
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade setuptools wheel
-    - name: Build
-      run: |
-        python setup.py bdist_wheel
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v1
-      with:
-        name: build-windows-32-27
-        path: dist
   build-windows-32-abi3:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.5
+    - name: Set up Python 3.6
       uses: actions/setup-python@v2
       with:
-        python-version: "3.5"
+        python-version: "3.6"
         architecture: x86
     - name: Install dependencies
       run: |
@@ -74,96 +48,12 @@ jobs:
       shell: bash
       run: |
         cd dist
-        python ../.github/workflows/rename_wheel.py *.whl - cp35 cp36 cp37 cp38 cp39 cp310
+        python ../.github/workflows/rename_wheel.py *.whl - cp36 cp37 cp38 cp39 cp310
     - name: Upload artifacts
       uses: actions/upload-artifact@v1
       with:
         name: build-windows-32-abi3
         path: dist
-  test-windows-32-27:
-    needs: [build-windows-32-27, sdist]
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 2.7
-      uses: actions/setup-python@v2
-      with:
-        python-version: "2.7"
-        architecture: x86
-    - name: Download build artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: build-windows-32-27
-    - name: Download sdist artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: sdist
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install pytest
-    - name: Install wheel
-      shell: bash
-      run: |
-        python -m pip install *.whl
-    - name: Test wheel with pytest
-      run: |
-        cd tests
-        python -m pytest
-    - name: Uninstall wheel
-      shell: bash
-      run: python -m pip uninstall -y nsmblib
-    - name: Install Microsoft Visual C++ Compiler for Python 2.7
-      uses: crazy-max/ghaction-chocolatey@v1
-      with:
-        args: install vcpython27
-    - name: Install sdist
-      shell: bash
-      run: python -m pip install *.tar.gz
-    - name: Test sdist with pytest
-      run: |
-        cd tests
-        python -m pytest
-  test-windows-32-35:
-    needs: [build-windows-32-abi3, sdist]
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.5
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.5"
-        architecture: x86
-    - name: Download build artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: build-windows-32-abi3
-    - name: Download sdist artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: sdist
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install pytest
-    - name: Install wheel
-      shell: bash
-      run: |
-        python -m pip install *.whl
-    - name: Test wheel with pytest
-      run: |
-        cd tests
-        python -m pytest
-    - name: Uninstall wheel
-      shell: bash
-      run: python -m pip uninstall -y nsmblib
-    - name: Install sdist
-      shell: bash
-      run: python -m pip install *.tar.gz
-    - name: Test sdist with pytest
-      run: |
-        cd tests
-        python -m pytest
   test-windows-32-36:
     needs: [build-windows-32-abi3, sdist]
     runs-on: windows-latest
@@ -364,40 +254,14 @@ jobs:
       run: |
         cd tests
         python -m pytest
-  build-windows-64-27:
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: ilammy/msvc-dev-cmd@v1
-    - name: Set up Python 2.7
-      uses: actions/setup-python@v2
-      with:
-        python-version: 2.7
-        architecture: x64
-    - name: Install Microsoft Visual C++ Compiler for Python 2.7
-      uses: crazy-max/ghaction-chocolatey@v1
-      with:
-        args: install vcpython27
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade setuptools wheel
-    - name: Build
-      run: |
-        python setup.py bdist_wheel
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v1
-      with:
-        name: build-windows-64-27
-        path: dist
   build-windows-64-abi3:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.5
+    - name: Set up Python 3.6
       uses: actions/setup-python@v2
       with:
-        python-version: "3.5"
+        python-version: "3.6"
         architecture: x64
     - name: Install dependencies
       run: |
@@ -411,96 +275,12 @@ jobs:
       shell: bash
       run: |
         cd dist
-        python ../.github/workflows/rename_wheel.py *.whl - cp35 cp36 cp37 cp38 cp39 cp310
+        python ../.github/workflows/rename_wheel.py *.whl - cp36 cp37 cp38 cp39 cp310
     - name: Upload artifacts
       uses: actions/upload-artifact@v1
       with:
         name: build-windows-64-abi3
         path: dist
-  test-windows-64-27:
-    needs: [build-windows-64-27, sdist]
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 2.7
-      uses: actions/setup-python@v2
-      with:
-        python-version: "2.7"
-        architecture: x64
-    - name: Download build artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: build-windows-64-27
-    - name: Download sdist artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: sdist
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install pytest
-    - name: Install wheel
-      shell: bash
-      run: |
-        python -m pip install *.whl
-    - name: Test wheel with pytest
-      run: |
-        cd tests
-        python -m pytest
-    - name: Uninstall wheel
-      shell: bash
-      run: python -m pip uninstall -y nsmblib
-    - name: Install Microsoft Visual C++ Compiler for Python 2.7
-      uses: crazy-max/ghaction-chocolatey@v1
-      with:
-        args: install vcpython27
-    - name: Install sdist
-      shell: bash
-      run: python -m pip install *.tar.gz
-    - name: Test sdist with pytest
-      run: |
-        cd tests
-        python -m pytest
-  test-windows-64-35:
-    needs: [build-windows-64-abi3, sdist]
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.5
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.5"
-        architecture: x64
-    - name: Download build artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: build-windows-64-abi3
-    - name: Download sdist artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: sdist
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install pytest
-    - name: Install wheel
-      shell: bash
-      run: |
-        python -m pip install *.whl
-    - name: Test wheel with pytest
-      run: |
-        cd tests
-        python -m pytest
-    - name: Uninstall wheel
-      shell: bash
-      run: python -m pip uninstall -y nsmblib
-    - name: Install sdist
-      shell: bash
-      run: python -m pip install *.tar.gz
-    - name: Test sdist with pytest
-      run: |
-        cd tests
-        python -m pytest
   test-windows-64-36:
     needs: [build-windows-64-abi3, sdist]
     runs-on: windows-latest
@@ -727,10 +507,10 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.5
+    - name: Set up Python 3.6
       uses: actions/setup-python@v2
       with:
-        python-version: "3.5"
+        python-version: "3.6"
         architecture: x64
     - name: Install dependencies
       run: |
@@ -744,7 +524,7 @@ jobs:
       shell: bash
       run: |
         cd dist
-        python ../.github/workflows/rename_wheel.py *.whl - cp35 cp36 cp37 cp38 cp39 cp310
+        python ../.github/workflows/rename_wheel.py *.whl - cp36 cp37 cp38 cp39 cp310
     - name: Upload artifacts
       uses: actions/upload-artifact@v1
       with:
@@ -764,46 +544,6 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: build-macos-64-27
-    - name: Download sdist artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: sdist
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install pytest
-    - name: Install wheel
-      shell: bash
-      run: |
-        python -m pip install *.whl
-    - name: Test wheel with pytest
-      run: |
-        cd tests
-        python -m pytest
-    - name: Uninstall wheel
-      shell: bash
-      run: python -m pip uninstall -y nsmblib
-    - name: Install sdist
-      shell: bash
-      run: python -m pip install *.tar.gz
-    - name: Test sdist with pytest
-      run: |
-        cd tests
-        python -m pytest
-  test-macos-64-35:
-    needs: [build-macos-64-abi3, sdist]
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.5
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.5"
-        architecture: x64
-    - name: Download build artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: build-macos-64-abi3
     - name: Download sdist artifact
       uses: actions/download-artifact@v2
       with:
@@ -1058,16 +798,16 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: |
-        /opt/python/cp35-cp35m/bin/python -m pip install --upgrade pip
-        /opt/python/cp35-cp35m/bin/python -m pip install --upgrade setuptools wheel packaging auditwheel
+        /opt/python/cp36-cp36m/bin/python -m pip install --upgrade pip
+        /opt/python/cp36-cp36m/bin/python -m pip install --upgrade setuptools wheel packaging auditwheel
     - name: Build
       shell: bash
       run: |
-        /opt/python/cp35-cp35m/bin/python setup.py bdist_wheel
+        /opt/python/cp36-cp36m/bin/python setup.py bdist_wheel
     - name: Run auditwheel
       run: |
         mkdir dist/wheelhouse
-        /opt/python/cp35-cp35m/bin/python -m auditwheel repair -w dist/wheelhouse/ dist/*.whl
+        /opt/python/cp36-cp36m/bin/python -m auditwheel repair -w dist/wheelhouse/ dist/*.whl
         rm dist/*.whl
         mv dist/wheelhouse/* dist/
         rm dist/*manylinux1*
@@ -1076,7 +816,7 @@ jobs:
       shell: bash
       run: |
         cd dist
-        /opt/python/cp35-cp35m/bin/python ../.github/workflows/rename_wheel.py *.whl - cp35 cp36 cp37 cp38 cp39 cp310
+        /opt/python/cp36-cp36m/bin/python ../.github/workflows/rename_wheel.py *.whl - cp36 cp37 cp38 cp39 cp310
     - name: Upload artifacts
       uses: actions/upload-artifact@v1
       with:
@@ -1122,42 +862,6 @@ jobs:
       run: |
         cd tests
         python -m pytest
-  test-ubuntu-64-35:
-    needs: [build-ubuntu-64-abi3, sdist]
-    runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux2014_x86_64
-    steps:
-    - uses: actions/checkout@v2
-    - name: Download build artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: build-ubuntu-64-abi3
-    - name: Download sdist artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: sdist
-    - name: Install dependencies
-      run: |
-        /opt/python/cp35-cp35m/bin/python -m pip install --upgrade pip
-        /opt/python/cp35-cp35m/bin/python -m pip install pytest
-    - name: Install wheel
-      shell: bash
-      run: |
-        /opt/python/cp35-cp35m/bin/python -m pip install *.whl
-    - name: Test wheel with pytest
-      run: |
-        cd tests
-        /opt/python/cp35-cp35m/bin/python -m pytest
-    - name: Uninstall wheel
-      shell: bash
-      run: /opt/python/cp35-cp35m/bin/python -m pip uninstall -y nsmblib
-    - name: Install sdist
-      shell: bash
-      run: /opt/python/cp35-cp35m/bin/python -m pip install *.tar.gz
-    - name: Test sdist with pytest
-      run: |
-        cd tests
-        /opt/python/cp35-cp35m/bin/python -m pytest
   test-ubuntu-64-36:
     needs: [build-ubuntu-64-abi3, sdist]
     runs-on: ubuntu-latest

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -48,12 +48,52 @@ jobs:
       shell: bash
       run: |
         cd dist
-        python ../.github/workflows/rename_wheel.py *.whl - cp36 cp37 cp38 cp39 cp310
+        python ../.github/workflows/rename_wheel.py *.whl - cp35 cp36 cp37 cp38 cp39 cp310
     - name: Upload artifacts
       uses: actions/upload-artifact@v1
       with:
         name: build-windows-32-abi3
         path: dist
+  test-windows-32-35:
+    needs: [build-windows-32-abi3, sdist]
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.5
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.5"
+        architecture: x86
+    - name: Download build artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: build-windows-32-abi3
+    - name: Download sdist artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: sdist
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest
+    - name: Install wheel
+      shell: bash
+      run: |
+        python -m pip install *.whl
+    - name: Test wheel with pytest
+      run: |
+        cd tests
+        python -m pytest
+    - name: Uninstall wheel
+      shell: bash
+      run: python -m pip uninstall -y nsmblib
+    - name: Install sdist
+      shell: bash
+      run: python -m pip install *.tar.gz
+    - name: Test sdist with pytest
+      run: |
+        cd tests
+        python -m pytest
   test-windows-32-36:
     needs: [build-windows-32-abi3, sdist]
     runs-on: windows-latest
@@ -275,12 +315,52 @@ jobs:
       shell: bash
       run: |
         cd dist
-        python ../.github/workflows/rename_wheel.py *.whl - cp36 cp37 cp38 cp39 cp310
+        python ../.github/workflows/rename_wheel.py *.whl - cp35 cp36 cp37 cp38 cp39 cp310
     - name: Upload artifacts
       uses: actions/upload-artifact@v1
       with:
         name: build-windows-64-abi3
         path: dist
+  test-windows-64-35:
+    needs: [build-windows-64-abi3, sdist]
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.5
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.5"
+        architecture: x64
+    - name: Download build artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: build-windows-64-abi3
+    - name: Download sdist artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: sdist
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest
+    - name: Install wheel
+      shell: bash
+      run: |
+        python -m pip install *.whl
+    - name: Test wheel with pytest
+      run: |
+        cd tests
+        python -m pytest
+    - name: Uninstall wheel
+      shell: bash
+      run: python -m pip uninstall -y nsmblib
+    - name: Install sdist
+      shell: bash
+      run: python -m pip install *.tar.gz
+    - name: Test sdist with pytest
+      run: |
+        cd tests
+        python -m pytest
   test-windows-64-36:
     needs: [build-windows-64-abi3, sdist]
     runs-on: windows-latest
@@ -524,7 +604,7 @@ jobs:
       shell: bash
       run: |
         cd dist
-        python ../.github/workflows/rename_wheel.py *.whl - cp36 cp37 cp38 cp39 cp310
+        python ../.github/workflows/rename_wheel.py *.whl - cp35 cp36 cp37 cp38 cp39 cp310
     - name: Upload artifacts
       uses: actions/upload-artifact@v1
       with:
@@ -544,6 +624,46 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: build-macos-64-27
+    - name: Download sdist artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: sdist
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest
+    - name: Install wheel
+      shell: bash
+      run: |
+        python -m pip install *.whl
+    - name: Test wheel with pytest
+      run: |
+        cd tests
+        python -m pytest
+    - name: Uninstall wheel
+      shell: bash
+      run: python -m pip uninstall -y nsmblib
+    - name: Install sdist
+      shell: bash
+      run: python -m pip install *.tar.gz
+    - name: Test sdist with pytest
+      run: |
+        cd tests
+        python -m pytest
+  test-macos-64-35:
+    needs: [build-macos-64-abi3, sdist]
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.5
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.5"
+        architecture: x64
+    - name: Download build artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: build-macos-64-abi3
     - name: Download sdist artifact
       uses: actions/download-artifact@v2
       with:
@@ -815,7 +935,7 @@ jobs:
       shell: bash
       run: |
         cd dist
-        /opt/python/cp36-cp36m/bin/python ../.github/workflows/rename_wheel.py *.whl - cp36 cp37 cp38 cp39 cp310
+        /opt/python/cp36-cp36m/bin/python ../.github/workflows/rename_wheel.py *.whl - cp35 cp36 cp37 cp38 cp39 cp310
     - name: Upload artifacts
       uses: actions/upload-artifact@v1
       with:
@@ -835,6 +955,46 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: build-ubuntu-64-27
+    - name: Download sdist artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: sdist
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest
+    - name: Install wheel
+      shell: bash
+      run: |
+        python -m pip install *.whl
+    - name: Test wheel with pytest
+      run: |
+        cd tests
+        python -m pytest
+    - name: Uninstall wheel
+      shell: bash
+      run: python -m pip uninstall -y nsmblib
+    - name: Install sdist
+      shell: bash
+      run: python -m pip install *.tar.gz
+    - name: Test sdist with pytest
+      run: |
+        cd tests
+        python -m pytest
+  test-ubuntu-64-35:
+    needs: [build-ubuntu-64-abi3, sdist]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.5
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.5"
+        architecture: x64
+    - name: Download build artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: build-ubuntu-64-abi3
     - name: Download sdist artifact
       uses: actions/download-artifact@v2
       with:

--- a/py27_manual_windows_build_instructions.txt
+++ b/py27_manual_windows_build_instructions.txt
@@ -1,0 +1,60 @@
+Build instructions for Python 2.7 on Windows
+--------------------------------------------
+
+This used to be done automatically on GitHub Actions, but unfortunately, now that Microsoft removed the official download for the Microsoft Visual C++ Compiler for Python 2.7 from their website, that's illegal (as the license only allows for personal use, and not for transfer to third parties such as a private GitHub repo). So from now on, Python 2.7 builds need to be created manually.
+
+I use VirtualBox VMs for this. I'm using Windows 7 because that's the simplest way to guarantee that the builds are compatible with any relatively modern Windows version, as opposed to building with, say, Windows 11. Start with clean 32-bit and 64-bit installations of Windows, and follow the instructions below for each one.
+
+
+Create VM checkpoint 1: start
+
+- Install/update software:
+    - Firefox (to access websites like python.org)
+    - I like to use magic-wormhole for transferring files between the host and guest, so for that, install/update the following:
+        - Python 3 (3.8.10 is the final 3.x build for Win7)
+            - Requires SP1, KB3063858, MSVC++ Redistributable for VS 2015
+        - pip (may have to run ensurepip first)
+        - magic-wormhole
+    - Any other tangential programs that might be useful
+- Transfer/download software:
+    - Python 2.7 installer (2.7.18 is the final 2.x build)
+    - Microsoft Visual C++ Compiler for Python 2.7 installer (VCForPython27.msi, available on archive.org: https://web.archive.org/web/20210106040224/https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi)
+      (note: filesize is about 84 MB, if you're wondering)
+
+Create VM checkpoint 2: Pre-setup complete
+
+- Install Python 2.7
+- (note: you need admin command prompt for the next two steps)
+- Update its pip (19.2.3 -> 20.3.4)
+- Install wheel, setuptools and pytest
+
+Create VM checkpoint 3: Python 2.7 installed
+
+- Install the MSVC++ Compiler for Py27
+  (note: there's no "successfully installed" window, it just closes itself when it's done)
+
+Create VM checkpoint 4: MSVC++ Compiler installed
+
+- Transfer repo source from host
+- Build wheel
+    (32-bit) py -2.7-32 setup.py bdist_wheel
+    (64-bit) py -2.7    setup.py bdist_wheel
+- Transfer wheel to host
+- Transfer latest sdist (from GitHub Actions) from host
+- Test sdist
+    py **** -m pip install *.tar.gz
+    cd tests
+    py **** -m pytest
+
+Revert to checkpoint 3 (before MSVC++ Compiler was installed)
+
+- Transfer repo source from host
+- Transfer wheel from host
+- Test wheel
+    py **** -m pip install *.whl
+    cd tests
+    py **** -m pytest
+
+If all tests succeeded, the wheel is now ready for release.
+
+Repeat the above procedure for the other architecture (32/64-bit).

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if os.name != 'nt':
 
 setup(
   name='nsmblib',
-  version='2021.10.13.0',
+  version='2021.10.14.0',
   ext_modules=[
     Extension(
       'nsmblib',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if os.name != 'nt':
 
 setup(
   name='nsmblib',
-  version='2021.01.10.0',
+  version='2021.10.13.0',
   ext_modules=[
     Extension(
       'nsmblib',


### PR DESCRIPTION
* Bump version number to 2021.10.14.0
* Python 3.10 is now supported
* We now build with Python 3.6 instead of 3.5, though we still include 3.5 in the wheel tags and run unit-tests against it
* We can't legally build for Python 2.7 on Windows in GHA anymore, so the CI infrastructure for that has been replaced with a guide on how to do it manually
* Properly handle the case where auditwheel adds multiple manylinux platform tags