### PR TITLE
Updates for 2021.10.14.1

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,22 +21,23 @@ Versions
 
 There are two main versions of the original NSMBLib in circulation, 0.4
 (bundled with Reggie!) and 0.5 (bundled with Puzzle). Version 0.5 adds an LZ11
-compression function (used by Puzzle), but it does not actually work correctly
+compression function (used by Puzzle), but it doesn't actually work correctly
 and produces mangled output data.
 
 NSMBLib-Updated includes a working LZ11 compression function, and is thus
 API-compatible with NSMBLib 0.5 (and backwards-compatible with 0.4).
 
-Since every release of NSMBLib-Updated has the exact same API as NSMBLib 0.5,
-NSMBLib-Updated uses calendar versioning to distinguish releases (which only
-ever fix bugs or broaden compatibility).
+Since NSMBLib-Updated is compatible with NSMBLib 0.5 and its API doesn't change
+often, it uses calendar versioning to distinguish releases (which usually just
+fix bugs or broaden compatibility).
 
 
-API
----
+Original NSMBLib API
+--------------------
 
 - `nsmblib.getVersion() -> int`:
   Returns the minor version number. For example, for NSMBLib 0.5, returns 5.
+  NSMBLib-Updated always returns 5.
 - `nsmblib.decompress11LZS(data: bytes) -> bytes`:
   Decompresses LZ11-compressed data.
 - `nsmblib.compress11LZS(data: bytes) -> bytes`:
@@ -48,6 +49,29 @@ API
   `image = QtGui.QImage(decodedData, 1024, 256, 4096, QtGui.QImage.Format_ARGB32_Premultiplied)`
 - `nsmblib.decodeTilesetNoAlpha(data: bytes) -> bytes`:
   Same as `decodeTileset()`, but locks the alpha channel for all pixels to 255.
+
+
+Additional API in NSMBLib-Updated
+---------------------------------
+
+The version in which each function was added is listed below for each function.
+Detecting their availability with `hasattr()` before attempting to use them is
+recommended.
+
+- `nsmblib.getUpdatedVersion() -> int`:
+  Returns the NSMBLib-Updated version number as a 10-digit decimal number. For
+  example, on NSMBLib-Updated 2021.10.14.1, this returns 2021101401.
+  *Added in 2021.10.14.1.*
+- `nsmblib.decodeTilesetNoPremultiplication(data: bytes) -> bytes`:
+  Same as `decodeTileset()`, but skips premultiplication. This is a bit more
+  accurate than `decodeTileset()` because premultiplication inherently reduces
+  color depth on semitransparent pixels. Use `QtGui.QImage.Format_ARGB32` when
+  loading this as a PyQt QImage.
+  *Added in 2021.10.14.1.*
+- `nsmblib.decodeTilesetNoPremultiplicationNoAlpha(data: bytes) -> bytes`:
+  Combination of `decodeTilesetNoPremultiplication()` and
+  `decodeTilesetNoAlpha()`.
+  *Added in 2021.10.14.1.*
 
 
 Original Readme

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if os.name != 'nt':
 
 setup(
   name='nsmblib',
-  version='2021.10.14.0',
+  version='2021.10.14.1',
   ext_modules=[
     Extension(
       'nsmblib',

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -6,3 +6,10 @@ def test_getVersion():
     Test getVersion()
     """
     assert nsmblib.getVersion() == 5
+
+
+def test_getUpdatedVersion():
+    """
+    Test getUpdatedVersion()
+    """
+    assert 2021000000 < nsmblib.getUpdatedVersion() < 3000000000

--- a/tests/test_rgb4a3.py
+++ b/tests/test_rgb4a3.py
@@ -25,7 +25,7 @@ def premultiply(r, g, b, a):
     return r, g, b, a
 
 
-def do_test_tileset_decode_function(func, alphaEnabled):
+def do_test_tileset_decode_function(func, alphaEnabled, premultiplyEnabled):
     """
     Generic function for testing decodeTileset() and decodeTilesetNoAlpha()
     """
@@ -77,7 +77,8 @@ def do_test_tileset_decode_function(func, alphaEnabled):
         # Compare
         error_msg = '%04x decoded incorrectly' % d
         if alphaEnabled:
-            red, green, blue, alpha = premultiply(red, green, blue, alpha)
+            if premultiplyEnabled:
+                red, green, blue, alpha = premultiply(red, green, blue, alpha)
             if alpha == 0:
                 assert a == 0, error_msg
             else:
@@ -90,11 +91,25 @@ def test_decodeTileset():
     """
     Test decodeTileset()
     """
-    do_test_tileset_decode_function(nsmblib.decodeTileset, True)
+    do_test_tileset_decode_function(nsmblib.decodeTileset, True, True)
 
 
 def test_decodeTilesetNoAlpha():
     """
     Test decodeTilesetNoAlpha()
     """
-    do_test_tileset_decode_function(nsmblib.decodeTilesetNoAlpha, False)
+    do_test_tileset_decode_function(nsmblib.decodeTilesetNoAlpha, False, True)
+
+
+def test_decodeTilesetNoPremultiplication():
+    """
+    Test decodeTilesetNoPremultiplication()
+    """
+    do_test_tileset_decode_function(nsmblib.decodeTilesetNoPremultiplication, True, False)
+
+
+def test_decodeTilesetNoPremultiplicationNoAlpha():
+    """
+    Test decodeTilesetNoPremultiplicationNoAlpha()
+    """
+    do_test_tileset_decode_function(nsmblib.decodeTilesetNoPremultiplicationNoAlpha, False, False)


### PR DESCRIPTION
- Add new functions for skipping alpha premultiplication
- Add new function for querying NSMBLib-Updated version number